### PR TITLE
Relax the cabal min version to allow building with ghc 865

### DIFF
--- a/eff/eff.cabal
+++ b/eff/eff.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 2.4
 name: eff
 version: 0.0.0.0
 category: Control


### PR DESCRIPTION
I'd love to test this on my pet project, but it only has ghc 8.6.5, which bundles cabal 2.4.

Sadly, I could not figure out how to run the tests with cabal :(
ghcid reports everything compiles, so maybe this is just fine?

Not sure if you want to take on the additional effort of maintaining cabal2.4/ghc8.6.5 min versions or what that would mean.