### PR TITLE
Remove the `liftWith`-like argument of `choice`

### DIFF
--- a/eff/src/Control/Effect/Error.hs
+++ b/eff/src/Control/Effect/Error.hs
@@ -34,7 +34,7 @@ class Monad m => Error e m where
 instance (Choice t, Scoped t, Error e m) => Error e (LiftT t m) where
   throw = lift . throw
   {-# INLINE throw #-}
-  catch m f = choice m (\m' -> scoped (catch m') id f) (\choose -> catch (choose m) (choose . f))
+  catch m f = choice m (\m' -> scoped (catch m') id f)
   {-# INLINE catch #-}
 
 instance Send (Error e) t m => Error e (EffT t m) where

--- a/eff/src/Control/Effect/Internal.hs
+++ b/eff/src/Control/Effect/Internal.hs
@@ -66,15 +66,13 @@ instance Scoped t => Scoped (LiftT t) where
   {-# INLINABLE scoped #-}
 
 instance Choice t => Choice (LiftT t) where
-  choice m f g = LiftT $ choice
-    (coerce m) (\m' -> coerce $ f (coerce <$> m'))
-    (\choose -> coerce <$> g (fmap coerce . choose . coerce))
+  choice m f = LiftT $ choice (coerce m) (\m' -> coerce $ f (coerce <$> m'))
   {-# INLINABLE choice #-}
 
 instance (Alternative m, Monad m, Choice t) => Alternative (LiftT t m) where
   empty = lift empty
   {-# INLINE empty #-}
-  a <|> b = choice a (\a' -> hmap (a' <|>) b) (\choose -> choose a <|> choose b)
+  a <|> b = choice a (\a' -> hmap (a' <|>) b)
   {-# INLINE (<|>) #-}
 
 instance (Alternative m, Monad m, Choice t) => MonadPlus (LiftT t m)
@@ -136,9 +134,7 @@ instance Scoped t => Scoped (EffT t) where
   {-# INLINABLE scoped #-}
 
 instance Choice t => Choice (EffT t) where
-  choice m f g = EffT $ choice
-    (coerce m) (\m' -> coerce $ f (coerce <$> m'))
-    (\choose -> coerce <$> g (fmap coerce . choose . coerce))
+  choice m f = EffT $ choice (coerce m) (\m' -> coerce $ f (coerce <$> m'))
   {-# INLINABLE choice #-}
 
 instance (Send Alternative t m, Monad (t m)) => Alternative (EffT t m) where

--- a/eff/src/Control/Effect/NonDet.hs
+++ b/eff/src/Control/Effect/NonDet.hs
@@ -141,7 +141,7 @@ instance Scoped NonDetT where
   {-# INLINABLE scoped #-}
 
 instance Choice NonDetT where
-  choice m0 f _ = go m0 where
+  choice m0 f = go m0 where
     go m = NonDetT $ runNonDetT (f (NonDetTState <$> runNonDetT m)) <&> \case
       Nothing      -> Nothing
       Just (x, m') -> Just (x, go m')


### PR DESCRIPTION
You've mentioned wanting to simplify the `Choice` interface, and this looks like likely to be a good step.

What used to be the third argument is now derived from the first two when needed, using the function `choiceGivenInterpreterBasedChoice`.

This probably isn't the best choice of function name, and I'm not sure every `choice` call site's behavior is perfectly preserved by this refactoring. Even if they are mostly preserved, I'd be wary of performance degradation here since the explicit `liftWith`-style arguments tended to be expressed in ways that were much more direct in implementation. (I haven't even tried to inline `choiceGivenInterpreterBasedChoice`.)

Hopefully this PR serves as a proof of concept at least. The `choiceGivenInterpreterBasedChoice` function is pretty simple, and I bet you'll be able to judge if it's a promising approach faster than I can.